### PR TITLE
Add gcc, musl-dev for aarch64 Docker image building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.9.2-alpine3.6 AS build
 
 # Install tools required to build the project
 # We need to run `docker build --no-cache .` to update those dependencies
-RUN apk add --no-cache git
+RUN apk add --no-cache gcc musl-dev git
 RUN go get github.com/golang/dep/cmd/dep
 
 # Gopkg.toml and Gopkg.lock lists project dependencies


### PR DESCRIPTION
When building docker image  on aarch64, I meet the error: 
"
Step 3/11 : RUN go get github.com/golang/dep/cmd/dep
 ---> Running in f1818e505227
# github.com/golang/dep/cmd/dep
/usr/local/go/pkg/tool/linux_arm64/link: running gcc failed: exec: "gcc": executable file not found in $PATH
"
This patch will solve this problem.
